### PR TITLE
Move to use CSI 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,3 @@ script:
   - make azuredisk
   - make integration-test
   - make azuredisk-windows
-  - make azuredisk-container

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
 before_install:
   - go get github.com/mattn/goveralls
   - go get github.com/rexray/gocsi/csc
+  - sudo apt update && sudo apt install procps -y  # for installing pkill
 
 script:
   - hack/verify-all.sh

--- a/README.md
+++ b/README.md
@@ -12,22 +12,16 @@ This driver allows Kubernetes to use [azure disk](https://azure.microsoft.com/en
 Status: Alpha
 
 ### Container Images:
-`mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.1.0-alpha`
+`mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.2.0-alpha`
 
 ### Driver parameters
 Please refer to [`disk.csi.azure.com` driver parameters](./docs/driver-parameters.md)
  > storage class `disk.csi.azure.com` parameters are compatible with built-in [azuredisk](https://kubernetes.io/docs/concepts/storage/volumes/#azuredisk) plugin
 
 ## Kubernetes User Guide
- - supported Kubernetes version: v1.12.0 or later version
+ - supported Kubernetes version: v1.13.0 or later version
  - supported agent OS: Linux
 ### Prerequisite
- - To ensure that all necessary features are enabled, set the following feature gate flags to true:
-```
---feature-gates=CSIPersistentVolume=true,MountPropagation=true,VolumeSnapshotDataSource=true,KubeletPluginsWatcher=true,CSINodeInfo=true,CSIDriverRegistry=true
-```
-`VolumeSnapshotDataSource` is a new alpha feature in v1.12. `KubeletPluginsWatcher` is enabled by default in v1.12. `CSINodeInfo` and `CSIDriverRegistry` are new alpha features in v1.12.
-
  - The driver initialization depends on a [Cloud provider config file](https://github.com/kubernetes/cloud-provider-azure/blob/master/docs/cloud-provider-config.md), usually it's `/etc/kubernetes/azure.json` on all k8s nodes deployed by AKS or aks-engine, here is an [azure.json example](./deploy/example/azure.json)
 
 ### Install azuredisk CSI driver on a Kubernetes cluster

--- a/deploy/azuredisk-csi-driver.yaml
+++ b/deploy/azuredisk-csi-driver.yaml
@@ -16,11 +16,15 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/driver-registrar:v0.4.1
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/disk.csi.azure.com /registration/disk.csi.azure.com-reg.sock"]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -34,7 +38,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: azuredisk
-          image: andyzhangx/azuredisk-csi:latest
+          image: andyzhangx/azuredisk-csi:v0.2.0-alpha
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/azuredisk-csi-driver.yaml
+++ b/deploy/azuredisk-csi-driver.yaml
@@ -38,7 +38,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: azuredisk
-          image: andyzhangx/azuredisk-csi:v0.2.0-alpha
+          image: mcr.microsoft.com/k8s/csi/azuredisk-csi:v0.2.0-alpha
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/azuredisk-csi-driver.yaml
+++ b/deploy/azuredisk-csi-driver.yaml
@@ -84,7 +84,7 @@ spec:
           name: mountpoint-dir
         - hostPath:
             path: /var/lib/kubelet/plugins_registry/
-            type: Directory
+            type: DirectoryOrCreate
           name: registration-dir
         - hostPath:
             path: /etc/kubernetes/

--- a/deploy/azuredisk-csi-driver.yaml
+++ b/deploy/azuredisk-csi-driver.yaml
@@ -83,7 +83,7 @@ spec:
             type: DirectoryOrCreate
           name: mountpoint-dir
         - hostPath:
-            path: /var/lib/kubelet/plugins
+            path: /var/lib/kubelet/plugins_registry/
             type: Directory
           name: registration-dir
         - hostPath:

--- a/deploy/csi-azuredisk-attacher.yaml
+++ b/deploy/csi-azuredisk-attacher.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.4.1
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/deploy/csi-azuredisk-provisioner.yaml
+++ b/deploy/csi-azuredisk-provisioner.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v0.4.1
+          image: quay.io/k8scsi/csi-provisioner:v1.0.1
           args:
             - "--provisioner=disk.csi.azure.com"
             - "--csi-address=$(ADDRESS)"

--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -34,8 +34,6 @@ if [ $# -gt 2 ]; then
 fi
 
 echo "being to run integration test on $cloud ..."
-# kill azurediskplugin first
-pkill azurediskplugin
 
 # run CSI driver as a background service
 _output/azurediskplugin --endpoint $endpoint --nodeid CSINode -v=5 &
@@ -96,5 +94,8 @@ retcode=$?
 if [ $retcode -gt 0 ]; then
 	exit $retcode
 fi
+
+# kill azurediskplugin first
+/usr/bin/pkill -f azurediskplugin
 
 echo "integration test on $cloud is completed."

--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -96,6 +96,7 @@ if [ $retcode -gt 0 ]; then
 fi
 
 # kill azurediskplugin first
+echo "pkill -f azurediskplugin"
 /usr/bin/pkill -f azurediskplugin
 
 echo "integration test on $cloud is completed."

--- a/test/integration/run-test.sh
+++ b/test/integration/run-test.sh
@@ -34,6 +34,9 @@ if [ $# -gt 2 ]; then
 fi
 
 echo "being to run integration test on $cloud ..."
+# kill azurediskplugin first
+pkill azurediskplugin
+
 # run CSI driver as a background service
 _output/azurediskplugin --endpoint $endpoint --nodeid CSINode -v=5 &
 sleep 10


### PR DESCRIPTION
This PR also fixed an issue: make attach disk idempotent, otherwise there would be error when attaching a disk to a node, like following(that's because original attach disk is not idempotent):
```
Events:
  Type     Reason                  Age                 From                               Message
  ----     ------                  ----                ----                               -------
  Normal   Scheduled               2m10s               default-scheduler                  Successfully assigned default/nginx-azuredisk to k8s-agentpool-34398540-0
  Warning  FailedAttachVolume      115s                attachdetach-controller            AttachVolume.Attach failed for volume "pvc-ce388ed4-2f9a-11e9-8ba9-000d3a004ffb" : attachment timeout for volume /subscriptions/b9d2281e-dcd5-4dfd-9a97-0d50377cdf76/resourceGroups/andy-mg1133/providers/Microsoft.Compute/disks/pvc-disk-dynamic-ce3ece4e-2f9a-11e9-bdd4-000d3a004896
  Warning  FailedAttachVolume      99s (x5 over 114s)  attachdetach-controller            AttachVolume.Attach failed for volume "pvc-ce388ed4-2f9a-11e9-8ba9-000d3a004ffb" : rpc error: code = DeadlineExceeded desc = context deadline exceeded
  Normal   SuccessfulAttachVolume  83s                 attachdetach-controller            AttachVolume.Attach succeeded for volume "pvc-ce388ed4-2f9a-11e9-8ba9-000d3a004ffb"
  Normal   Pulling                 55s                 kubelet, k8s-agentpool-34398540-0  pulling image "nginx"
  Normal   Pulled                  52s                 kubelet, k8s-agentpool-34398540-0  Successfully pulled image "nginx"
  Normal   Created                 48s                 kubelet, k8s-agentpool-34398540-0  Created container
  Normal   Started                 47s                 kubelet, k8s-agentpool-34398540-0  Started container
 
```